### PR TITLE
Add issue/PR management information

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help improve the Fonda
+title: ''
+labels: kind/bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment:**
+ - OS: [e.g. CentOS]
+ - Version: [e.g. 2.0.0]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help improve the Fonda
 title: ''
-labels: kind/bug
+labels: bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Request a feature implementation
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Background**
+A clear and concise description of what the problem is. Ex. At the moment, Fonda does not allow [...] and it would be nice to [...] because [...]
+
+**Approach**
+A clear and concise description of what you want to happen.
+
+**Other options**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,32 @@
+# Description
+
+Fixes #[related_issue_number]
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+- [ ] This change consists of tests extending or updating
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
+Please also list any relevant details for your test configuration.
+
+- Test 1
+- Test 2
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] New and existing unit and integrations tests pass locally with my changes
+- [ ] I have analyzed my own code (via `PMD`, `checkstyle`, `JaCoCo`) by `./gradlew check` command
+- [ ] I have commented on my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my fix is effective or that my feature works

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,14 @@
 #Contributing Guidelines
+
+Thanks for your interest in Fonda. Our goal is to offer a scalable and automatic analysis of multiple NGS sequencing data types.
+
+- [Branches management guidelines](#branches-management-guidelines)
+- [CI process description](#ci-process-description)
+- [Contributions](#contributions)
+    - [Reporting Bugs](#reporting-bugs)
+    - [Suggesting Enhancements](#suggesting-enhancements)
+    - [Pull Requests](#pull-requests)
+
 ## Branches management guidelines
 
 * Default repository branch: `develop`. It contains all the latest changes, which are merged via the `Pull Requests`
@@ -76,3 +86,58 @@ fn_branch1      |
  | fonda-*.zip | ----------------->  || _|_|_|_|_|_ ||  ----------------->  |             | 
  |_____________|       to S3         ||_|_|_|_|_|_|_||    to user           |_____________|
 ```
+
+## Contributions
+
+You can get started to contribute to the Fonda in several ways by creating:
+- issue: [reporting bugs](#reporting-bugs) or [suggesting enhancements](#suggesting-enhancements)
+- [pull requests](#pull-requests)
+
+**Issues** are the way to track the problems, ideas, questions that would be raised while using the code in a repository.
+These can include bugs to fix, features to add, or documentation that looks outdated. 
+It can also be used to keep track of tasks, enhancements for the codebase.
+The issue shall be discussed by repository maintainers and contributors first. If the issue is relevant and requires a solution, then it should be implemented and updated in the repository via pull request.
+
+**Pull request** allows you made a feature implementation or a bug-fix in the code to a repository.  
+Maintainers can see the changes and suggest modifications in the code. 
+If the changes are acceptable, they can merge it to the branch requested.
+
+### Reporting Bugs
+
+This section guide is submitting a bug report for Fonda.
+
+Bugs are tracked as GitHub [issues](https://github.com/epam/fonda/issues). Create an issue on the repository and provide the bug information by filling in the [template](https://github.com/epam/fonda/blob/develop/.github/ISSUE_TEMPLATE/bug_report.md).
+This will keep your bugs tidy and relevant. 
+When you are creating a bug report, please include as many details as possible.
+
+> **Note**: Before creating bug reports, please check the bug is not already described in existing [issues](https://github.com/epam/fonda/issues).
+
+### Suggesting Enhancements
+
+This section guide is submitting an enhancement suggestion for Fonda.
+
+Enhancement suggestions are tracked as GitHub [issues](https://github.com/epam/fonda/issues). 
+Create an issue on the repository and provide the enhancement information by filling in the [template](https://github.com/epam/fonda/blob/develop/.github/ISSUE_TEMPLATE/feature_request.md).
+
+### Pull Requests
+
+This section guide is submitting an pull requests for Fonda.
+
+Contributions to Fonda should be made in the form of GitHub pull [requests](https://github.com/epam/fonda/pulls).
+Create an PR on the repository and describe the enhancement by filling in the [template](https://github.com/epam/fonda/blob/develop/.github/ISSUE_TEMPLATE/pull_request_template.md).
+Each pull request will be reviewed by a core Fonda maintainers who has appropriate permissions.
+
+Please follow these steps to have your contribution considered by the maintainers:
+
+- Branch from the `develop` branch. If needed, rebase to the current `develop`
+  branch before submitting your pull request. If it doesn't merge cleanly with
+  master you may be asked to rebase your changes.
+
+- Each PR should compile and pass tests.
+
+- Each PR should pass `PMD`, `checkstyle`, `JaCoCo` checks.
+
+- Add tests relevant to the fixed bug or new feature.  
+
+
+>_All code in this repository is under the Apache License, Version 2.0._


### PR DESCRIPTION
This PR relates to  #136 

The pull request consists of: 
* `Contributions` section was added to `CONTRIBUTING.md`
* `bug_report.md` and `feature_request.md` templates were added to ` .github/ISSUE_TEMPLATE` folder 
* `pull_request_template.md` template was added to  `.github/PULL_REQUEST_TEMPLATE` folder 